### PR TITLE
Implementation of signer-provider wrapper

### DIFF
--- a/protocol/substrate/signer-provider-js/src/__tests__/e2e.spec.ts
+++ b/protocol/substrate/signer-provider-js/src/__tests__/e2e.spec.ts
@@ -2,10 +2,10 @@ import { PolywrapClient } from "@polywrap/client-js";
 import { substrateSignerProviderPlugin } from "../";
 import { enableFn } from "./mockExtensionInjector";
 import { injectExtension } from '@polkadot/extension-inject';
-import { web3Accounts, web3Enable, web3FromSource } from '@polkadot/extension-dapp';
-import { stringToHex } from "@polkadot/util";
+import { u8aToHex } from "@polkadot/util";
+import { cryptoWaitReady, decodeAddress, signatureVerify } from '@polkadot/util-crypto';
 
-import { Account } from '../wrap';
+import { Account, SignerResult } from '../wrap';
 
 describe("e2e", () => {
 
@@ -42,24 +42,53 @@ describe("e2e", () => {
     expect(accounts[0].meta.name).toBe("alice");
   });
 
-  it("Can use injected provider to sign data (smoke test)", async () => {
-    await web3Enable('e2e testing dApp');
-    const allAccounts = await web3Accounts();
-    const account = allAccounts[0];
-    const injector = await web3FromSource(account.meta.source);
-    const signRaw = injector?.signer?.signRaw;
+  it("signRaw produces a valid signature from test account", async () => {
+    const account = await getAccount();
+    const data = "123"; // to be signed
 
-    if (!!signRaw) {
-        // WHY DO I NEED TO BIND HERE??
-        const { signature } = await signRaw.bind(injector.signer)({
-            address: account.address,
-            data: stringToHex('message to sign'),
-            type: 'bytes'
-        });
-        console.log(signature);
-    }
+    const result = await client.invoke({
+      uri,
+      method: "signRaw",
+      args: { payload: { address: account.address, data } }
+    });
 
+    expect(result.error).toBeFalsy();
+    expect(result.data).toBeTruthy();
+    const signerResult = result.data as SignerResult;
+    expect(isValidSignature(data, signerResult.signature, account.address));
   });
 
+  it("signRaw throws if an unmanaged account address is requested", async () => {
+    const unmanagedAddress = "000000000000000000000000000000000000000000000000"; 
+
+    const result = await client.invoke({
+      uri,
+      method: "signRaw",
+      args: { payload: { address: unmanagedAddress, data: "aaa" } }
+    });
+
+    expect(result.error?.message).toContain("Provider does not contain account: "+ unmanagedAddress);
+  });
+
+  // -- helpers -- //
+
+  async function getAccount(): Promise<Account> {
+    const accountsResult = await client.invoke({
+        uri,
+        method: "getAccounts",
+        args: {},
+      });
+      const accounts: Account[] = accountsResult.data as Account[];
+      return accounts[0]
+  }
+
+  async function isValidSignature(signedMessage: string, signature: string, address: string): Promise<boolean> {
+    await cryptoWaitReady();
+    const publicKey = decodeAddress(address);
+    const hexPublicKey = u8aToHex(publicKey);
+    return signatureVerify(signedMessage, signature, hexPublicKey).isValid;
+  }
 
 });
+
+

--- a/protocol/substrate/signer-provider-js/src/__tests__/testPayload.ts
+++ b/protocol/substrate/signer-provider-js/src/__tests__/testPayload.ts
@@ -1,0 +1,19 @@
+import { SignerPayloadJSON } from '../wrap';
+
+/**
+ * Produces a minimal valid extrinsic payload in JSON form that can be used in testing
+ */
+export const testPayload = (address: string): SignerPayloadJSON => ({
+  address,
+  blockHash: "0x91820de8e05dc861baa91d75c34b23ac778f5fb4a88bd9e8480dbe3850d19a26",
+  blockNumber: "0",
+  era: "0x0703",
+  genesisHash: "0x91820de8e05dc861baa91d75c34b23ac778f5fb4a88bd9e8480dbe3850d19a26",
+  method: "0x0900142248692122",
+  nonce: "0",
+  specVersion: "1",
+  tip: "0",
+  transactionVersion: "",
+  signedExtensions: [],
+  version: 4,
+});

--- a/protocol/substrate/signer-provider-js/src/index.ts
+++ b/protocol/substrate/signer-provider-js/src/index.ts
@@ -1,6 +1,7 @@
 import {
   Args_getAccounts,
-  Args_signAndSubmitExtrinsic,
+  Args_signPayload,
+  Args_signRaw, 
   Module,
   manifest,
   SignerResult,
@@ -8,7 +9,8 @@ import {
 } from "./wrap";
 
 import { Client, PluginFactory } from "@polywrap/core-js";
-import { web3Accounts, web3Enable } from '@polkadot/extension-dapp';
+import { web3Accounts, web3Enable, web3FromSource } from '@polkadot/extension-dapp';
+import type { Signer } from '@polkadot/api/types';
 
 export interface SubstrateSignerProviderPluginConfig {}
 
@@ -27,15 +29,30 @@ export class SubstrateSignerProviderPlugin extends Module<SubstrateSignerProvide
     return await web3Accounts();
   }
 
-  async signAndSubmitExtrinsic(
-    args: Args_signAndSubmitExtrinsic,
+  async signPayload(
+    { payload }: Args_signPayload,
     client: Client
   ): Promise<SignerResult> {
     await this._enableProvider();
-    return {
-      id: 0,
-      signature: "foo"
+    const { address } = payload;
+    const signer = await this._getSigner(address);
+    if (!signer || !signer?.signPayload) {
+      throw new Error("Provider for account: " + address + " does not have payload signing capabilities");
     }
+    return signer.signPayload(payload);
+  }
+
+  async signRaw(
+    { payload }: Args_signRaw,
+    client: Client
+  ): Promise<SignerResult> {
+    await this._enableProvider();
+    const { address } = payload;
+    const signer = await this._getSigner(address);
+    if (!signer || !signer?.signRaw) {
+      throw new Error("Provider for account: " + address + " does not have raw signing capabilities");
+    }
+    return signer.signRaw({ ...payload, type: 'bytes' });
   }
 
   private async _enableProvider(): Promise<void> {
@@ -44,6 +61,25 @@ export class SubstrateSignerProviderPlugin extends Module<SubstrateSignerProvide
     }
     await web3Enable("substrate-signer-provider-plugin");
     this._isProviderEnabled = true;
+  }
+
+
+  /**
+   * Searches the injected web3 providers for any accounts that match the 
+   * given address and then return associated Signer.
+   *
+   * Requires this._enableProvider() be called first
+   */
+  private async _getSigner(address: String): Promise<Signer> {
+    const accounts = await await web3Accounts();
+    const signingAccount = accounts.find(acc => acc.address == address);
+
+    if (!signingAccount) {
+      throw new Error("Provider does not contain account: " + address);
+    }
+
+    const injector = await web3FromSource(signingAccount.meta.source);
+    return injector?.signer
   }
 }
 

--- a/protocol/substrate/signer-provider-js/src/schema.graphql
+++ b/protocol/substrate/signer-provider-js/src/schema.graphql
@@ -1,9 +1,12 @@
 type Module {
   getAccounts: [Account!]!
 
-  signAndSubmitExtrinsic(
-    address: String!
-    data: Bytes!
+  signPayload(
+    payload: SignerPayloadJSON!
+  ): SignerResult!
+
+  signRaw(
+    payload: SignerPayloadRaw!
   ): SignerResult!
 }
 
@@ -20,7 +23,93 @@ type AccountMetadata {
   source: String!
 }
 
+type SignerPayloadJSON {
+  """
+  The ss-58 encoded address
+  """
+  address: String!
+
+  """
+  The checkpoint hash of the block, in hex
+  """
+  blockHash: String!
+
+  """
+  The checkpoint block number, in hex
+  """
+  blockNumber: String!
+
+  """
+  The era for this transaction, in hex
+  """
+  era: String!
+
+  """
+  The genesis hash of the chain, in hex
+  """
+  genesisHash: String!
+
+  """
+  The encoded method (with arguments) in hex
+  """
+  method: String!
+
+  """
+  The nonce for this transaction, in hex
+  """
+  nonce: String!
+
+  """
+  The current spec version for the runtime
+  """
+  specVersion: String!
+
+  """
+  The tip for this transaction, in hex
+  """
+  tip: String!
+
+  """
+  The current transaction version for the runtime
+  """
+  transactionVersion: String!
+
+  """
+  The applicable signed extensions for this runtime
+  """
+  signedExtensions: [String!]!
+
+  """
+  The version of the extrinsic we are dealing with
+  """
+  version: UInt32!
+}
+
+type SignerPayloadRaw {
+  """
+  The hex-encoded data for this request
+  """
+  data: String!
+
+  """
+  The ss-58 encoded address
+  """
+  address: String!
+
+  """
+  The type of the contained data ('bytes' | 'payload')
+  """
+  type: String!
+}
+
 type SignerResult {
+  """
+  The id for this request
+  """
   id: UInt32!
+
+  """
+  The resulting signature in hex
+  """
   signature: String!
 }


### PR DESCRIPTION
Closes #9 

- Updates the interface for signer-provider including new type defs in the schema
- Adds implementation of the `signRaw` and `signPayload` methods
- - These basically just pass their args forward with some error handling logic
- Includes tests for both the new signing methods using the mock polkadot extension

## Testing

New additions are limited to the `signer-provider` wrapper. Tests can be run by running (from the substrate/signer-provider directory)
```shell
yarn
yarn codegen
yarn test
```
