### PR TITLE
Adds tests for the RPC-wrapper that use the browser based signer

### DIFF
--- a/protocol/substrate/rpc-wrapper/babel.config.js
+++ b/protocol/substrate/rpc-wrapper/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@polkadot/dev/config/babel-config-cjs.cjs');

--- a/protocol/substrate/rpc-wrapper/jest.config.js
+++ b/protocol/substrate/rpc-wrapper/jest.config.js
@@ -2,11 +2,15 @@ module.exports = {
   collectCoverage: true,
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  testMatch: ["**/tests/*.spec.ts"],
-  globals: {
-    'ts-jest': {
-      tsconfig: "tsconfig.json",
-      diagnostics: false
-    }
-  }
+  "testMatch": [
+    "**/tests/**/*.+(spec|test).+(ts|tsx|js)",
+    "**/?(*.)+(spec|test).+(ts|tsx|js)"
+  ],
+  "transform": {
+    "\\.[j]sx?$": "babel-jest",
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
+  transformIgnorePatterns: [
+    "node_modules/(?!@polkadot|@babel/runtime/helpers/esm/|uuid/dist/esm-browser/)"
+  ],
 };

--- a/protocol/substrate/rpc-wrapper/jest.config.js
+++ b/protocol/substrate/rpc-wrapper/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   collectCoverage: true,
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   testMatch: ["**/tests/*.spec.ts"],
   globals: {
     'ts-jest': {

--- a/protocol/substrate/rpc-wrapper/package.json
+++ b/protocol/substrate/rpc-wrapper/package.json
@@ -19,6 +19,9 @@
   },
   "devDependencies": {
     "@polkadot/extension-inject": "^0.44.6",
+    "@polkadot/types": "^9.4.2",
+    "@polkadot/util": "^10.1.8",
+    "@polkadot/util-crypto": "^10.1.8",
     "@polywrap/client-js": "0.5.0",
     "@polywrap/test-env-js": "0.5.0",
     "@types/jest": "29",

--- a/protocol/substrate/rpc-wrapper/package.json
+++ b/protocol/substrate/rpc-wrapper/package.json
@@ -26,6 +26,7 @@
     "substrate-polywrap-test-env": "0.0.1",
     "ts-jest": "29",
     "ts-node": "8.10.2",
-    "typescript": "4.0.7"
+    "typescript": "4.0.7",
+    "substrate-signer-provider-plugin-js": "0.1.0"
   }
 }

--- a/protocol/substrate/rpc-wrapper/package.json
+++ b/protocol/substrate/rpc-wrapper/package.json
@@ -8,7 +8,7 @@
     "fmt": "cd module && cargo +nightly fmt",
     "test": "yarn test:e2e",
     "test:e2e": "yarn test:e2e:codegen && jest --passWithNoTests --runInBand --verbose",
-    "test:e2e:codegen": "cd tests && npx polywrap app codegen -g wrap",
+    "test:e2e:codegen": "cd tests && polywrap app codegen -g wrap",
     "clean": "rm -rf module/src/wrap && rm -rf test/wrap",
     "rebuild": "yarn clean && yarn codegen && yarn build",
     "deploy": "npx polywrap deploy",
@@ -18,12 +18,13 @@
     "polywrap": "0.5.0"
   },
   "devDependencies": {
-    "substrate-polywrap-test-env": "0.0.1",
-    "@types/jest": "27.0.2",
     "@polywrap/client-js": "0.5.0",
     "@polywrap/test-env-js": "0.5.0",
-    "jest": "27.0.6",
-    "ts-jest": "27.0.4",
+    "@types/jest": "29",
+    "jest": "29",
+    "jest-environment-jsdom": "^29.0.3",
+    "substrate-polywrap-test-env": "0.0.1",
+    "ts-jest": "29",
     "ts-node": "8.10.2",
     "typescript": "4.0.7"
   }

--- a/protocol/substrate/rpc-wrapper/package.json
+++ b/protocol/substrate/rpc-wrapper/package.json
@@ -18,15 +18,17 @@
     "polywrap": "0.5.0"
   },
   "devDependencies": {
+    "@polkadot/extension-inject": "^0.44.6",
     "@polywrap/client-js": "0.5.0",
     "@polywrap/test-env-js": "0.5.0",
     "@types/jest": "29",
     "jest": "29",
     "jest-environment-jsdom": "^29.0.3",
+    "mock-polkadot-js-extension": "0.1.0",
     "substrate-polywrap-test-env": "0.0.1",
+    "substrate-signer-provider-plugin-js": "0.1.0",
     "ts-jest": "29",
     "ts-node": "8.10.2",
-    "typescript": "4.0.7",
-    "substrate-signer-provider-plugin-js": "0.1.0"
+    "typescript": "4.0.7"
   }
 }

--- a/protocol/substrate/rpc-wrapper/src/types/extrinsics.rs
+++ b/protocol/substrate/rpc-wrapper/src/types/extrinsics.rs
@@ -285,6 +285,15 @@ mod tests {
         let _xt = UncheckedExtrinsicV4::try_from(signed_payload).unwrap();
     }
 
+
+    #[test]
+    fn decode_encoded_payload() {
+        let payload_hex = "0xb9018400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01aa976fea2fb2e941b3d74590375a578196a9c793100e7731539409b889d5321b27c183e484be0dcadf67366d384577692b66fb671823ec668dff946afd72958ea816000009001022686922";
+        let payload_bytes = <Vec<u8>>::from_hex(payload_hex).unwrap();
+        let extrinsic = UncheckedExtrinsicV4::<Vec<u8>>::decode(&mut payload_bytes.as_slice());
+        println!("{:?}", extrinsic);
+    }
+
     fn gen_valid_signature() -> (sr25519::Pair, MultiSignature) {
         let msg = &b"test-message"[..];
         let (pair, _) = sr25519::Pair::generate();

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -9,6 +9,8 @@ import { PolywrapClient, Uri } from "@polywrap/client-js";
 // import { runCLI } from "@polywrap/test-env-js";
 import path from "path";
 // import { up, down } from "substrate-polywrap-test-env";
+import { TextEncoder, TextDecoder } from "util";
+
 
 jest.setTimeout(360000);
 let url: string;
@@ -18,6 +20,11 @@ describe("e2e", () => {
   const uri = new Uri("file/" + path.join(__dirname, "../build")).uri;
 
   beforeAll(async () => {
+
+    // polyfill text encoder
+    global.TextEncoder = TextEncoder;
+    // @ts-ignore
+    global.TextDecoder = TextDecoder;
 
     // // start up a test chain environment
     // console.log("Starting up test chain. This can take around 1 minute..");

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -266,15 +266,15 @@ it("can get signer-provider managed accounts. Returns Alice", async () => {
   // This is a known good payload taken from polkadot-js tests
   const testExtrinsic: SignerPayload = {
     address: aliceAddr,
-    blockHash: "0x91820de8e05dc861baa91d75c34b23ac778f5fb4a88bd9e8480dbe3850d19a26",
-    blockNumber: 0,
-    era: "0x0703",
-    genesisHash: "0x91820de8e05dc861baa91d75c34b23ac778f5fb4a88bd9e8480dbe3850d19a26",
-    method: "0x0900142248692122",
+    blockHash: "0x661f57d206d4fecda0408943427d4d25436518acbff543735e7569da9db6bdd7",
+    blockNumber: 99,
+    era: "0xb502",
+    genesisHash: "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
+    method: "0x0403c6111b239376e5e8b983dc2d2459cbb6caed64cc1d21723973d061ae0861ef690b00b04e2bde6f",
     nonce: 0,
-    specVersion: 1,
-    tip: "9999999", // BigInt is just a string in polywrap
-    transactionVersion: 1,
+    specVersion: 2,
+    tip: "0", // BigInt is just a string in polywrap
+    transactionVersion: 4,
     signedExtensions: [],
     version: 4,
   }
@@ -298,6 +298,22 @@ it("can get signer-provider managed accounts. Returns Alice", async () => {
       .createType('ExtrinsicPayload', testExtrinsic, { version: testExtrinsic.version })
       .toHex();
     expect(isValidSignature(encodedPayload, result.data?.signature!, aliceAddr))
+  });
+
+  it("Can sign and submit an extrinsic to the chain", async () => {
+     const result = await Substrate_Module.signAndSend(
+      {
+        url,
+        extrinsic: testExtrinsic
+      },
+      client,
+      uri
+    );
+
+    expect(result).toBeTruthy();
+    expect(result.error).toBeFalsy();
+    expect(result.data).toBeTruthy();
+
   });
 
   async function isValidSignature(signedMessage: string, signature: string, address: string): Promise<boolean> {

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -268,13 +268,13 @@ it("can get signer-provider managed accounts. Returns Alice", async () => {
     address: aliceAddr,
     blockHash: "0x661f57d206d4fecda0408943427d4d25436518acbff543735e7569da9db6bdd7",
     blockNumber: 99,
-    era: "0xb502",
-    genesisHash: "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
-    method: "0x0403c6111b239376e5e8b983dc2d2459cbb6caed64cc1d21723973d061ae0861ef690b00b04e2bde6f",
+    era: "0x0000",
+    genesisHash: "0x91820de8e05dc861baa91d75c34b23ac778f5fb4a88bd9e8480dbe3850d19a26",
+    method: "0x09003022737570206e657264732122",
     nonce: 0,
-    specVersion: 2,
+    specVersion: 100,
     tip: "0", // BigInt is just a string in polywrap
-    transactionVersion: 4,
+    transactionVersion: 1,
     signedExtensions: [],
     version: 4,
   }
@@ -298,11 +298,6 @@ it("can get signer-provider managed accounts. Returns Alice", async () => {
       .createType('ExtrinsicPayload', testExtrinsic, { version: testExtrinsic.version })
       .toHex();
     expect(isValidSignature(encodedPayload, result.data?.signature!, aliceAddr))
-
-    console.log("signatrue!!", result.data?.signature)
-  // 14be43eac146553939056897fc14cb7fa8c5d949323d864d63870429d4c934238374f7a5cd917307cf62a1ae28de09ae8afd1e592c283dc74ab51d89238c9c8f
-  // 0x01fc96482a604c4bfc2650d397f75d28c72dccf81e618abb3e0d32e05e4da24f57224b83b3f154bb2ac247521c4bd3d4d0d25aa20bedc05055376f37fd42ed3389
-
   });
 
   it("Can send a signed extrinsic to the chain", async () => {

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -6,9 +6,9 @@ import {
   Substrate_AccountInfo,
 } from "./wrap";
 import { PolywrapClient, Uri } from "@polywrap/client-js";
-import { runCLI } from "@polywrap/test-env-js";
+// import { runCLI } from "@polywrap/test-env-js";
 import path from "path";
-import { up, down } from "substrate-polywrap-test-env";
+// import { up, down } from "substrate-polywrap-test-env";
 
 jest.setTimeout(360000);
 let url: string;
@@ -19,31 +19,32 @@ describe("e2e", () => {
 
   beforeAll(async () => {
 
-    // start up a test chain environment
-    console.log("Starting up test chain. This can take around 1 minute..");
-    const response = await up(false);
-    url = response.node.url;
-    console.log("Test chain running at ", url);
+    // // start up a test chain environment
+    // console.log("Starting up test chain. This can take around 1 minute..");
+    // const response = await up(false);
+    // url = response.node.url;
+    // console.log("Test chain running at ", url);
 
-    const wrapperDir = path.resolve(__dirname, "../");
+    // const wrapperDir = path.resolve(__dirname, "../");
 
-    const buildOutput = await runCLI({
-      args: ["build"],
-      cwd: wrapperDir
-    });
+    // const buildOutput = await runCLI({
+    //   args: ["build"],
+    //   cwd: wrapperDir
+    // });
 
-    if (buildOutput.exitCode !== 0) {
-      throw Error(
-        `Failed to build wrapper:\n` +
-        JSON.stringify(buildOutput, null, 2)
-      );
-    }
+    // if (buildOutput.exitCode !== 0) {
+    //   throw Error(
+    //     `Failed to build wrapper:\n` +
+    //     JSON.stringify(buildOutput, null, 2)
+    //   );
+    // }
+    url = "http://localhost:9933"
 
     client = new PolywrapClient();
   });
 
   afterAll(async () => {
-    await down();
+    // await down();
   })
 
   it("blockHash", async () => {

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -7,9 +7,9 @@ import {
   Substrate_SignerProvider_SignerPayloadJSON as SignerPayload,
 } from "./wrap";
 import { PolywrapClient, Uri } from "@polywrap/client-js";
-// import { runCLI } from "@polywrap/test-env-js";
+import { runCLI } from "@polywrap/test-env-js";
 import path from "path";
-// import { up, down } from "substrate-polywrap-test-env";
+import { up, down } from "substrate-polywrap-test-env";
 import { TextEncoder, TextDecoder } from "util";
 import { substrateSignerProviderPlugin } from "substrate-signer-provider-plugin-js";
 import { enableFn } from "mock-polkadot-js-extension";
@@ -33,29 +33,28 @@ describe("e2e", () => {
     // @ts-ignore
     global.TextDecoder = TextDecoder;
 
-// injects the mock extension into the page
+    // injects the mock extension into the page for the signer-provider to use
     await injectExtension(enableFn, { name: 'mockExtension', version: '1.0.0' });    
 
-    // // start up a test chain environment
-    // console.log("Starting up test chain. This can take around 1 minute..");
-    // const response = await up(false);
-    // url = response.node.url;
-    // console.log("Test chain running at ", url);
+    // start up a test chain environment
+    console.log("Starting up test chain. This can take around 1 minute..");
+    const response = await up(false);
+    url = response.node.url;
+    console.log("Test chain running at ", url);
 
-    // const wrapperDir = path.resolve(__dirname, "../");
+    const wrapperDir = path.resolve(__dirname, "../");
 
-    // const buildOutput = await runCLI({
-    //   args: ["build"],
-    //   cwd: wrapperDir
-    // });
+    const buildOutput = await runCLI({
+      args: ["build"],
+      cwd: wrapperDir
+    });
 
-    // if (buildOutput.exitCode !== 0) {
-    //   throw Error(
-    //     `Failed to build wrapper:\n` +
-    //     JSON.stringify(buildOutput, null, 2)
-    //   );
-    // }
-    url = "http://localhost:9933"
+    if (buildOutput.exitCode !== 0) {
+      throw Error(
+        `Failed to build wrapper:\n` +
+        JSON.stringify(buildOutput, null, 2)
+      );
+    }
 
     client = new PolywrapClient({
       plugins: [
@@ -68,7 +67,7 @@ describe("e2e", () => {
   });
 
   afterAll(async () => {
-    // await down();
+    await down();
   })
 
   it("blockHash", async () => {

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -11,6 +11,8 @@ import path from "path";
 // import { up, down } from "substrate-polywrap-test-env";
 import { TextEncoder, TextDecoder } from "util";
 import { substrateSignerProviderPlugin } from "substrate-signer-provider-plugin-js";
+import { enableFn } from "mock-polkadot-js-extension";
+import { injectExtension } from '@polkadot/extension-inject';
 
 
 jest.setTimeout(360000);
@@ -26,6 +28,9 @@ describe("e2e", () => {
     global.TextEncoder = TextEncoder;
     // @ts-ignore
     global.TextDecoder = TextDecoder;
+
+// injects the mock extension into the page
+    await injectExtension(enableFn, { name: 'mockExtension', version: '1.0.0' });    
 
     // // start up a test chain environment
     // console.log("Starting up test chain. This can take around 1 minute..");

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -10,6 +10,7 @@ import { PolywrapClient, Uri } from "@polywrap/client-js";
 import path from "path";
 // import { up, down } from "substrate-polywrap-test-env";
 import { TextEncoder, TextDecoder } from "util";
+import { substrateSignerProviderPlugin } from "substrate-signer-provider-plugin-js";
 
 
 jest.setTimeout(360000);
@@ -21,7 +22,7 @@ describe("e2e", () => {
 
   beforeAll(async () => {
 
-    // polyfill text encoder
+    // polyfill text encoder. This is required to test in the jsdom environment
     global.TextEncoder = TextEncoder;
     // @ts-ignore
     global.TextDecoder = TextDecoder;
@@ -47,7 +48,14 @@ describe("e2e", () => {
     // }
     url = "http://localhost:9933"
 
-    client = new PolywrapClient();
+    client = new PolywrapClient({
+      plugins: [
+        {
+          uri: "ens/substrate-signer-provider.chainsafe.eth",
+          plugin: substrateSignerProviderPlugin({})
+        }
+      ]
+    });
   });
 
   afterAll(async () => {

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -220,11 +220,13 @@ describe("e2e", () => {
     expect(result).toBeTruthy();
   });
 
-  it("get account info of Alice", async () => {
+  const aliceAddr = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  it("get account info of Alice from chain", async () => {
     const result = await Substrate_Module.accountInfo({
         url,
         //Alice account
-        account: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        account: aliceAddr,
       },
       client,
       uri
@@ -238,7 +240,7 @@ describe("e2e", () => {
     console.log("account info: ", account_info);
   });
 
-it("get signer-provider managed accounts", async () => {
+it("can get signer-provider managed accounts. Returns Alice", async () => {
     const result = await Substrate_Module.getSignerProviderAccounts(
       {},
       client,
@@ -248,5 +250,13 @@ it("get signer-provider managed accounts", async () => {
     expect(result).toBeTruthy();
     expect(result.error).toBeFalsy();
     expect(result.data).toBeTruthy();
+    expect(result.data).toStrictEqual([
+      {
+        address: aliceAddr,
+        meta: { genesisHash: null, name: 'alice', source: 'mockExtension' },
+        type: 'sr25519'
+      }
+    ]);
+    
   });  
 });

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -232,4 +232,16 @@ describe("e2e", () => {
     const account_info: Substrate_AccountInfo = result.data!;
     console.log("account info: ", account_info);
   });
+
+it("get signer-provider managed accounts", async () => {
+    const result = await Substrate_Module.getSignerProviderAccounts(
+      {},
+      client,
+      uri
+    );
+
+    expect(result).toBeTruthy();
+    expect(result.error).toBeFalsy();
+    expect(result.data).toBeTruthy();
+  });  
 });

--- a/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
+++ b/protocol/substrate/rpc-wrapper/tests/e2e.spec.ts
@@ -298,21 +298,35 @@ it("can get signer-provider managed accounts. Returns Alice", async () => {
       .createType('ExtrinsicPayload', testExtrinsic, { version: testExtrinsic.version })
       .toHex();
     expect(isValidSignature(encodedPayload, result.data?.signature!, aliceAddr))
+
+    console.log("signatrue!!", result.data?.signature)
+  // 14be43eac146553939056897fc14cb7fa8c5d949323d864d63870429d4c934238374f7a5cd917307cf62a1ae28de09ae8afd1e592c283dc74ab51d89238c9c8f
+  // 0x01fc96482a604c4bfc2650d397f75d28c72dccf81e618abb3e0d32e05e4da24f57224b83b3f154bb2ac247521c4bd3d4d0d25aa20bedc05055376f37fd42ed3389
+
   });
 
-  it("Can sign and submit an extrinsic to the chain", async () => {
-     const result = await Substrate_Module.signAndSend(
+  it("Can send a signed extrinsic to the chain", async () => {
+     const signerResult = await Substrate_Module.sign(
       {
-        url,
         extrinsic: testExtrinsic
       },
       client,
       uri
     );
+    const signedPayload = signerResult.data!;
 
-    expect(result).toBeTruthy();
-    expect(result.error).toBeFalsy();
-    expect(result.data).toBeTruthy();
+    const sendResult = await Substrate_Module.send(
+      {
+        url,
+        signedExtrinsic: signedPayload
+      },
+      client,
+      uri
+    );
+
+    expect(sendResult).toBeTruthy();
+    expect(sendResult.error).toBeFalsy();
+    expect(sendResult.data).toBeTruthy();
 
   });
 

--- a/protocol/substrate/yarn.lock
+++ b/protocol/substrate/yarn.lock
@@ -1723,7 +1723,7 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/core@^27.0.6", "@jest/core@^27.5.1":
+"@jest/core@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.5.1.tgz#267ac5f704e09dc52de2922cbf3af9edcd64b626"
   integrity sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==
@@ -3591,13 +3591,13 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/jest@27.0.2":
-  version "27.0.2"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.2.tgz#ac383c4d4aaddd29bbf2b916d8d105c304a5fcd7"
-  integrity sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==
+"@types/jest@29":
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.0.3.tgz#b61a5ed100850686b8d3c5e28e3a1926b2001b59"
+  integrity sha512-F6ukyCTwbfsEX5F2YmVYmM5TcTHy1q9P5rWlRbrk56KyMh3v9xRGUO3aa8+SkvMi0SHXtASJv1283enXimC0Og==
   dependencies:
-    jest-diff "^27.0.0"
-    pretty-format "^27.0.0"
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/jest@^25.2.1":
   version "25.2.3"
@@ -7009,7 +7009,7 @@ expect@^27.5.1:
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
 
-expect@^29.0.3:
+expect@^29.0.0, expect@^29.0.3:
   version "29.0.3"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.0.3.tgz#6be65ddb945202f143c4e07c083f4f39f3bd326f"
   integrity sha512-t8l5DTws3212VbmPL+tBFXhjRHLmctHB0oQbL8eUc6S7NzZtYUhycrFO9mkxA0ZUC6FAWdNi7JchJSkODtcu1Q==
@@ -9171,7 +9171,7 @@ jest-cli@^25.5.4:
     realpath-native "^2.0.0"
     yargs "^15.3.1"
 
-jest-cli@^27.0.6, jest-cli@^27.5.1:
+jest-cli@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.5.1.tgz#278794a6e6458ea8029547e6c6cbf673bd30b145"
   integrity sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==
@@ -9300,7 +9300,7 @@ jest-diff@^25.2.1, jest-diff@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
-jest-diff@^27.0.0, jest-diff@^27.5.1:
+jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -10066,7 +10066,7 @@ jest-util@^27.0.0, jest-util@^27.5.1:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-util@^29.0.3:
+jest-util@^29.0.0, jest-util@^29.0.3:
   version "29.0.3"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.0.3.tgz#06d1d77f9a1bea380f121897d78695902959fbc0"
   integrity sha512-Q0xaG3YRG8QiTC4R6fHjHQPaPpz9pJBEi0AeOE4mQh/FuWOijFjGXMMOfQEaU9i3z76cNR7FobZZUQnL6IyfdQ==
@@ -10200,14 +10200,15 @@ jest-worker@^29.0.3:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.0.6.tgz#10517b2a628f0409087fbf473db44777d7a04505"
-  integrity sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==
+jest@29, jest@^29.0.3:
+  version "29.0.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.0.3.tgz#5227a0596d30791b2649eea347e4aa97f734944d"
+  integrity sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==
   dependencies:
-    "@jest/core" "^27.0.6"
+    "@jest/core" "^29.0.3"
+    "@jest/types" "^29.0.3"
     import-local "^3.0.2"
-    jest-cli "^27.0.6"
+    jest-cli "^29.0.3"
 
 jest@^25.3.0:
   version "25.5.4"
@@ -10226,16 +10227,6 @@ jest@^27.0.0-next.9:
     "@jest/core" "^27.5.1"
     import-local "^3.0.2"
     jest-cli "^27.5.1"
-
-jest@^29.0.3:
-  version "29.0.3"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-29.0.3.tgz#5227a0596d30791b2649eea347e4aa97f734944d"
-  integrity sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==
-  dependencies:
-    "@jest/core" "^29.0.3"
-    "@jest/types" "^29.0.3"
-    import-local "^3.0.2"
-    jest-cli "^29.0.3"
 
 jpjs@^1.2.1:
   version "1.2.1"
@@ -10737,7 +10728,7 @@ lodash.upperfirst@^4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
-lodash@4.x, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11078,7 +11069,7 @@ mkdirp@0.x, mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-mkdirp@1.x, mkdirp@^1.0.4:
+mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -12183,7 +12174,7 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
-pretty-format@^27.0.0, pretty-format@^27.5.1:
+pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
@@ -12192,7 +12183,7 @@ pretty-format@^27.0.0, pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-pretty-format@^29.0.3:
+pretty-format@^29.0.0, pretty-format@^29.0.3:
   version "29.0.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.0.3.tgz#23d5f8cabc9cbf209a77d49409d093d61166a811"
   integrity sha512-cHudsvQr1K5vNVLbvYF/nv3Qy/F/BcEKxGuIeMiVMRHxPOO1RxXooP8g/ZrwAp7Dx+KdMZoOc7NxLHhMrP2f9Q==
@@ -13981,21 +13972,19 @@ ts-invariant@^0.4.0:
   dependencies:
     tslib "^1.9.3"
 
-ts-jest@27.0.4:
-  version "27.0.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.4.tgz#df49683535831560ccb58f94c023d831b1b80df0"
-  integrity sha512-c4E1ECy9Xz2WGfTMyHbSaArlIva7Wi2p43QOMmCqjSSjHP06KXv+aT+eSY+yZMuqsMi3k7pyGsGj2q5oSl5WfQ==
+ts-jest@29:
+  version "29.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.2.tgz#0c45a1ac45d14f8b3bf89bca9048a2840c7bd5ad"
+  integrity sha512-P03IUItnAjG6RkJXtjjD5pu0TryQFOwcb1YKmW63rO19V0UFqL3wiXZrmR5D7qYjI98btzIOAcYafLZ0GHAcQg==
   dependencies:
     bs-logger "0.x"
-    buffer-from "1.x"
     fast-json-stable-stringify "2.x"
-    jest-util "^27.0.0"
-    json5 "2.x"
-    lodash "4.x"
+    jest-util "^29.0.0"
+    json5 "^2.2.1"
+    lodash.memoize "4.x"
     make-error "1.x"
-    mkdirp "1.x"
     semver "7.x"
-    yargs-parser "20.x"
+    yargs-parser "^21.0.1"
 
 ts-jest@^25.3.1:
   version "25.5.1"
@@ -15067,7 +15056,7 @@ yargs-parser@^16.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^21.0.0:
+yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==

--- a/protocol/substrate/yarn.lock
+++ b/protocol/substrate/yarn.lock
@@ -2702,6 +2702,15 @@
     "@polkadot/util" "10.1.8"
     "@polkadot/util-crypto" "10.1.8"
 
+"@polkadot/keyring@^10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-10.1.9.tgz#56c4e31e8cdb9ebcdf992c19603ee53a4c90451c"
+  integrity sha512-oUYhvfOCzyMA+SJ+O5BasQYYalmMkVBRHADASFNAxVBMbOl1DKNQx3tgpUZlbA95UzRPjKbV0RplhAIzb5CzVQ==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/util" "10.1.9"
+    "@polkadot/util-crypto" "10.1.9"
+
 "@polkadot/networks@10.1.8", "@polkadot/networks@^10.1.8":
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-10.1.8.tgz#0b07dcbe0b4685986677a27f7ac7e176b8ca10dc"
@@ -2710,6 +2719,15 @@
     "@babel/runtime" "^7.19.0"
     "@polkadot/util" "10.1.8"
     "@substrate/ss58-registry" "^1.29.0"
+
+"@polkadot/networks@10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-10.1.9.tgz#37e789dd13c683b3e8cdc16edff4983d5f94e28f"
+  integrity sha512-38bYoXYszJMTRSvhJOkfKXlIyTiFjJ1ZG7cyMYBOi1YtO9USd4lH0gknVfqXa1dyPyNvsOwI5RCKGFjbx2BEAw==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/util" "10.1.9"
+    "@substrate/ss58-registry" "^1.29.1"
 
 "@polkadot/rpc-augment@9.4.1":
   version "9.4.1"
@@ -2763,6 +2781,16 @@
     "@polkadot/types-codec" "9.4.1"
     "@polkadot/util" "^10.1.8"
 
+"@polkadot/types-augment@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-augment/-/types-augment-9.4.2.tgz#2ea0f6405d77413b84eafad9ac024ebf130841f3"
+  integrity sha512-HZx7VJmN1wBDI9TqmIdZSOC7PEU+yAaCzt0YTnovdLVnhXjOh2zeE5A3i8j0YzMXMQX110FZU/g8aq49WlTZGw==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/types" "9.4.2"
+    "@polkadot/types-codec" "9.4.2"
+    "@polkadot/util" "^10.1.9"
+
 "@polkadot/types-codec@9.4.1", "@polkadot/types-codec@^9.4.1":
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-9.4.1.tgz#451d0d4207b3fef2141a51a1e9a8d0245236017a"
@@ -2772,6 +2800,15 @@
     "@polkadot/util" "^10.1.8"
     "@polkadot/x-bigint" "^10.1.8"
 
+"@polkadot/types-codec@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-codec/-/types-codec-9.4.2.tgz#bf679356f7c26cc9bb99cc0bf6b72e93d62f504e"
+  integrity sha512-4nF1Okwzri8N22fCgsGvtzI+Vmwn9YKdFxsqUi5rRaHNvZiS4nCy9dS/6AUqbmh8n2AjbNcmATtY4hSDUNoaDA==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/util" "^10.1.9"
+    "@polkadot/x-bigint" "^10.1.9"
+
 "@polkadot/types-create@9.4.1":
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-9.4.1.tgz#1889d74dfb31aa84ecaad40d5c88560c0c51cac0"
@@ -2780,6 +2817,15 @@
     "@babel/runtime" "^7.19.0"
     "@polkadot/types-codec" "9.4.1"
     "@polkadot/util" "^10.1.8"
+
+"@polkadot/types-create@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-create/-/types-create-9.4.2.tgz#1b416d4fbe3e7c2999999138c5a525e349b376e9"
+  integrity sha512-SB1/UZ+uKgd5CPqnr5/IVDDBzImalivltDDbxFhsPqzUPqsskIGF2nsnAFr/GAq6kxXTuGHvjArMnY2xW0qpGQ==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/types-codec" "9.4.2"
+    "@polkadot/util" "^10.1.9"
 
 "@polkadot/types-known@9.4.1":
   version "9.4.1"
@@ -2815,6 +2861,20 @@
     "@polkadot/util-crypto" "^10.1.8"
     rxjs "^7.5.6"
 
+"@polkadot/types@9.4.2", "@polkadot/types@^9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-9.4.2.tgz#cbcf34d91b6fc938eec4be7a1583a176e0780ac5"
+  integrity sha512-uOkB2oj7eu29bJ6hG6U2cBYAXqF5Jzx91S484NNfAitWHzvCwr4GFxvTn4ogTbxvMaXJsn9O8/IwV0L69reZ0g==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/keyring" "^10.1.9"
+    "@polkadot/types-augment" "9.4.2"
+    "@polkadot/types-codec" "9.4.2"
+    "@polkadot/types-create" "9.4.2"
+    "@polkadot/util" "^10.1.9"
+    "@polkadot/util-crypto" "^10.1.9"
+    rxjs "^7.5.6"
+
 "@polkadot/util-crypto@10.1.8", "@polkadot/util-crypto@^10.1.5", "@polkadot/util-crypto@^10.1.7", "@polkadot/util-crypto@^10.1.8":
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-10.1.8.tgz#344bb1a1475baa66fb8feb621a79f41943904543"
@@ -2832,6 +2892,23 @@
     ed2curve "^0.3.0"
     tweetnacl "^1.0.3"
 
+"@polkadot/util-crypto@10.1.9", "@polkadot/util-crypto@^10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-10.1.9.tgz#807ffd4c8bb20ffe6eb446a74a3a8725c845acf1"
+  integrity sha512-wmrT5M8dOaSklnKwk7Wg6TjJzLYm5YCVJW97ziz5ulfN7LFbOwtPQ3fpk6uzBmnrRNXpI5hjYzzTKEyHrZZqhA==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.7.0"
+    "@polkadot/networks" "10.1.9"
+    "@polkadot/util" "10.1.9"
+    "@polkadot/wasm-crypto" "^6.3.1"
+    "@polkadot/x-bigint" "10.1.9"
+    "@polkadot/x-randomvalues" "10.1.9"
+    "@scure/base" "1.1.1"
+    ed2curve "^0.3.0"
+    tweetnacl "^1.0.3"
+
 "@polkadot/util@10.1.8", "@polkadot/util@^10.1.5", "@polkadot/util@^10.1.8":
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-10.1.8.tgz#8c6b9c23d4608cc020b5d5f187befa3ab585ab11"
@@ -2842,6 +2919,19 @@
     "@polkadot/x-global" "10.1.8"
     "@polkadot/x-textdecoder" "10.1.8"
     "@polkadot/x-textencoder" "10.1.8"
+    "@types/bn.js" "^5.1.1"
+    bn.js "^5.2.1"
+
+"@polkadot/util@10.1.9", "@polkadot/util@^10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-10.1.9.tgz#0280a830881ccb4c7c428ef8b5669db87c16d71b"
+  integrity sha512-nbXE7dqfsP38uHwMXBoL5s2x+5PXsGZIfWa0bjCdy6RwF6btqFTo7ryi0kzkco/kil0EZ3QaB+EJxVVaAwX2bA==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/x-bigint" "10.1.9"
+    "@polkadot/x-global" "10.1.9"
+    "@polkadot/x-textdecoder" "10.1.9"
+    "@polkadot/x-textencoder" "10.1.9"
     "@types/bn.js" "^5.1.1"
     bn.js "^5.2.1"
 
@@ -2904,6 +2994,14 @@
     "@babel/runtime" "^7.19.0"
     "@polkadot/x-global" "10.1.8"
 
+"@polkadot/x-bigint@10.1.9", "@polkadot/x-bigint@^10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-bigint/-/x-bigint-10.1.9.tgz#d8b450df90f3cb0e2b1f2583d35a184cc3d6ad50"
+  integrity sha512-1iA30V8+FdVK0I1kRSShTV/XgjBtC5Gl2EQl2Z9rrkK27mtjgIr14hD4nFfM176UgKvERinfDXzzRFU/p5w/Mg==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/x-global" "10.1.9"
+
 "@polkadot/x-fetch@^10.1.8":
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-10.1.8.tgz#3c271839593f1515f19d9b71a86cc448ca441c85"
@@ -2921,6 +3019,13 @@
   dependencies:
     "@babel/runtime" "^7.19.0"
 
+"@polkadot/x-global@10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-10.1.9.tgz#a2a380ed7816cfc553ca9b73dc401c36fbafaaef"
+  integrity sha512-arsQEUbUccEI8pt0Bngk66vpJlMC/sZ38xivwrR8MVi2u8FdWFwb7udvwGRbXujHmPgGfRqxQujheKSR3d2ToA==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+
 "@polkadot/x-randomvalues@10.1.8":
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-10.1.8.tgz#7da02e6aea33df22d6daafd333e9dfc4a357f265"
@@ -2928,6 +3033,14 @@
   dependencies:
     "@babel/runtime" "^7.19.0"
     "@polkadot/x-global" "10.1.8"
+
+"@polkadot/x-randomvalues@10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-10.1.9.tgz#a2c769b6090d768590bed5d32d8c1b4415e695c9"
+  integrity sha512-owSk4vVuy18kZI+L8pLV8Zt8Blsv0BM7j0VcNu4q6gdsduU4a5entGr3t2a3P4dj3hU65B4KgbSy516y//jMng==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/x-global" "10.1.9"
 
 "@polkadot/x-textdecoder@10.1.8":
   version "10.1.8"
@@ -2937,6 +3050,14 @@
     "@babel/runtime" "^7.19.0"
     "@polkadot/x-global" "10.1.8"
 
+"@polkadot/x-textdecoder@10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-10.1.9.tgz#25cf4947626a96373b18a29a37f8761cc1de3b04"
+  integrity sha512-RSe1qgbaJ6+dnmKR+yIYt9uKfZreJQns1sSQBJra49xBk2ImQmon7wwu19TjycR6kCEdI2WGRdZaa8kkrgIsYQ==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/x-global" "10.1.9"
+
 "@polkadot/x-textencoder@10.1.8":
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-10.1.8.tgz#f8169d8026a86d512a9bc925317d53d132984cd1"
@@ -2944,6 +3065,14 @@
   dependencies:
     "@babel/runtime" "^7.19.0"
     "@polkadot/x-global" "10.1.8"
+
+"@polkadot/x-textencoder@10.1.9":
+  version "10.1.9"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-10.1.9.tgz#81f169b783e72185c5f907afc2b918b1c80d2b21"
+  integrity sha512-IXW4+G2r6wTpcxCGi2PeGd1aQRv0+FsgD9L7FDVjCejdgk6W87knIAaFTTYEmIF/x1clUqhw3c5Gxb0lUOchUw==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
+    "@polkadot/x-global" "10.1.9"
 
 "@polkadot/x-ws@^10.1.8":
   version "10.1.8"
@@ -3399,6 +3528,11 @@
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.29.0.tgz#0dea078271b5318c5eff7176e1df1f9b2c27e43f"
   integrity sha512-KTqwZgTjtWPhCAUJJx9qswP/p9cRKUU9GOHYUDKNdISFDiFafWmpI54JHfYLkgjvkSKEUgRZnvLpe0LMF1fXvw==
+
+"@substrate/ss58-registry@^1.29.1":
+  version "1.29.1"
+  resolved "https://registry.yarnpkg.com/@substrate/ss58-registry/-/ss58-registry-1.29.1.tgz#6070fc3cdf24ad8b3eba1eb7bdf4d96804615775"
+  integrity sha512-7+DeSVpUS2m+7HAeYvvypbnrYVat1b7ze2V9SV3d+pTbUHkovZACaHYm33FBHc9F+RpXgYgf+pikJXK5ux4o1g==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"


### PR DESCRIPTION
This PR allows the rpc-signer tests to run in the "jsdom" environment which is a requirement of using the injected extension signer.

Closes #28

- Adds a test showing the RPC wrapper can access accounts managed by the signer-provider
- Add a test showing the RPC wrapper can sign payloads using the signer-provider
- (failing) Adds a test for submitting a signed transaction using the RPC wrapper
- Adds a fix where signatures were being incorrectly decoded

The failing test will be fixed in a subsequent PR